### PR TITLE
Allow outputName replacements

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,28 @@ Yeah it's permit. I don't add too many limititation.
 
 Maybe you would need your classname without origin classname in some case.
 ```
+
 #### `outputName`
 
 filename of the `.js/.json`
 
 Default: `style`
+
+You can set the output format of your `.js/.json` file's filename.
+
+Take this source file `mystyle.css` as the example:
+
+* keeping original filename
+
+`[name]` => output: `mystyle.js/json`
+
+* with prefix and keeping original filename
+
+`prefix-[name]` => output: `prefix-mystyle.js/json`
+
+* with prefix, suffix keeping original filename
+
+`prefix-[name]-suffix` => output: `prefix-mystyle-suffix.js/json`
 
 #### `dist`
 

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ function writefile(pair, type) {
 module.exports = postcss.plugin('postcss-classname', function (opts) {
   opts = opts || {};
   var dist = opts.dist || ".",
-    outputName = opts.outputName || "style",
-    type = opts.type || ".js",
-    hashType = opts.hashType || "md5",
-    digestType = opts.digestType || "base32",
-    classnameFormat = opts.classnameFormat || "[classname]-[hash]",
-    maxLength = opts.maxLength || 6,
-    outputFile;
+      outputName = opts.outputName || "style",
+      type = opts.type || ".js",
+      hashType = opts.hashType || "md5",
+      digestType = opts.digestType || "base32",
+      classnameFormat = opts.classnameFormat || "[classname]-[hash]",
+      maxLength = opts.maxLength || 6,
+      outputFile;
 
   if (type[0] !== '.')
     type = '.' + type;

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ function writefile(pair, type) {
 module.exports = postcss.plugin('postcss-classname', function (opts) {
   opts = opts || {};
   var dist = opts.dist || ".",
-      outputName = opts.outputName || "style",
-      type = opts.type || ".js",
-      hashType = opts.hashType || "md5",
-      digestType = opts.digestType || "base32",
-      classnameFormat = opts.classnameFormat || "[classname]-[hash]",
-      maxLength = opts.maxLength || 6,
-      outputFile;
+    outputName = opts.outputName || "style",
+    type = opts.type || ".js",
+    hashType = opts.hashType || "md5",
+    digestType = opts.digestType || "base32",
+    classnameFormat = opts.classnameFormat || "[classname]-[hash]",
+    maxLength = opts.maxLength || 6,
+    outputFile;
 
   if (type[0] !== '.')
     type = '.' + type;
@@ -58,7 +58,13 @@ module.exports = postcss.plugin('postcss-classname', function (opts) {
     if (sourcePath) {
       var currentPath = path.dirname(sourcePath);
       currentPath = path.resolve(currentPath, dist);
-      outputFile = currentPath + '/' + outputName + type;
+      // process outputName replacements if any
+      var sourcePathParsed = path.parse(sourcePath),
+        filename = outputName;
+      if (typeof outputName === 'string') {
+        filename = filename.replace(/\[name\]/gi, sourcePathParsed.name);
+      }
+      outputFile = currentPath + '/' + filename + type;
     } else {
       outputFile = [dist, outputName].join('/');
       outputFile += type;


### PR DESCRIPTION
When source file's path is known, allows for processing of `outputName` property by supporting a `[name]` word, similar to existing formatting support for `classnameFormat`property.

This allows the plugin to be used in cases where there are multiple source files being processed in the same directory:

```
gulp.src(['./styles/*.css'])
.pipe(
    postcss(    
      [ require('postcss-hash-classname')({ outputName: '[name]' }) ]
    )
)
```

... and where before, output `.js/.json` files would overwrite each other.
