### PR TITLE
Allow outputName callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,14 @@ Take this source file `mystyle.css` as the example:
 
 `prefix-[name]-suffix` => output: `prefix-mystyle-suffix.js/json`
 
+You can also make `outputName` a callback function that resolves the file on the spot.
+
+The callback function will get the source file's path passed as only argument if source file is known:
+
+* use callback function
+
+function (source) { return (source ? path.parse(source).name : 'style'; } => output: `mystyle.js/json`
+
 #### `dist`
 
 destination folder of your output js/json

--- a/README.md
+++ b/README.md
@@ -137,11 +137,28 @@ Yeah it's permit. I don't add too many limititation.
 
 Maybe you would need your classname without origin classname in some case.
 ```
+
 #### `outputName`
 
 filename of the `.js/.json`
 
 Default: `style`
+
+You can set the output format of your `.js/.json` file's filename.
+
+Take this source file `mystyle.css` as the example:
+
+* keeping original filename
+
+`[name]` => output: `mystyle.js/json`
+
+* with prefix and keeping original filename
+
+`prefix-[name]` => output: `prefix-mystyle.js/json`
+
+* with prefix, suffix keeping original filename
+
+`prefix-[name]-suffix` => output: `prefix-mystyle-suffix.js/json`
 
 #### `dist`
 

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ function writefile(pair, type) {
 module.exports = postcss.plugin('postcss-classname', function (opts) {
   opts = opts || {};
   var dist = opts.dist || ".",
-    outputName = opts.outputName || "style",
-    type = opts.type || ".js",
-    hashType = opts.hashType || "md5",
-    digestType = opts.digestType || "base32",
-    classnameFormat = opts.classnameFormat || "[classname]-[hash]",
-    maxLength = opts.maxLength || 6,
-    outputFile;
+      outputName = opts.outputName || "style",
+      type = opts.type || ".js",
+      hashType = opts.hashType || "md5",
+      digestType = opts.digestType || "base32",
+      classnameFormat = opts.classnameFormat || "[classname]-[hash]",
+      maxLength = opts.maxLength || 6,
+      outputFile;
 
   if (type[0] !== '.')
     type = '.' + type;

--- a/index.js
+++ b/index.js
@@ -59,10 +59,12 @@ module.exports = postcss.plugin('postcss-classname', function (opts) {
       var currentPath = path.dirname(sourcePath);
       currentPath = path.resolve(currentPath, dist);
       // process outputName replacements if any
-      var sourcePathParsed = path.parse(sourcePath),
-        filename = outputName;
+      var filename = outputName;
       if (typeof outputName === 'string') {
+        var sourcePathParsed = path.parse(sourcePath)
         filename = filename.replace(/\[name\]/gi, sourcePathParsed.name);
+      } else if (typeof outputName === 'function') {
+        filename = outputName(sourcePath);
       }
       outputFile = currentPath + '/' + filename + type;
     } else {

--- a/index.js
+++ b/index.js
@@ -15,13 +15,13 @@ function writefile(pair, type) {
 module.exports = postcss.plugin('postcss-classname', function (opts) {
   opts = opts || {};
   var dist = opts.dist || ".",
-      outputName = opts.outputName || "style",
-      type = opts.type || ".js",
-      hashType = opts.hashType || "md5",
-      digestType = opts.digestType || "base32",
-      classnameFormat = opts.classnameFormat || "[classname]-[hash]",
-      maxLength = opts.maxLength || 6,
-      outputFile;
+    outputName = opts.outputName || "style",
+    type = opts.type || ".js",
+    hashType = opts.hashType || "md5",
+    digestType = opts.digestType || "base32",
+    classnameFormat = opts.classnameFormat || "[classname]-[hash]",
+    maxLength = opts.maxLength || 6,
+    outputFile;
 
   if (type[0] !== '.')
     type = '.' + type;
@@ -58,7 +58,13 @@ module.exports = postcss.plugin('postcss-classname', function (opts) {
     if (sourcePath) {
       var currentPath = path.dirname(sourcePath);
       currentPath = path.resolve(currentPath, dist);
-      outputFile = currentPath + '/' + outputName + type;
+      // process outputName replacements if any
+      var sourcePathParsed = path.parse(sourcePath),
+        filename = outputName;
+      if (typeof outputName === 'string') {
+        filename = filename.replace(/\[name\]/gi, sourcePathParsed.name);
+      }
+      outputFile = currentPath + '/' + filename + type;
     } else {
       outputFile = [dist, outputName].join('/');
       outputFile += type;

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = postcss.plugin('postcss-classname', function (opts) {
     if (sourcePath) {
       var currentPath = path.dirname(sourcePath);
       currentPath = path.resolve(currentPath, dist);
-      // process outputName replacements if any
+      // process outputName replacements or callbacks if any
       var filename = outputName;
       if (typeof outputName === 'string') {
         var sourcePathParsed = path.parse(sourcePath)


### PR DESCRIPTION
When source file's path is known, allows for processing of `outputName` property by supporting the property to have for it's value a callback function of type `(src) => { return 'style'; }`.
This extends the functionality already proposed in PR #10, by allowing for more dynamic customization to the output file's name during processing and based on the source file's filename.

This allows the plugin to be used in cases where there are multiple source files being processed in the same directory:

```
gulp.src(['./styles/*.css'])
.pipe(
    postcss(    
       [ require('postcss-hash-classname')({ outputName: (src) => { return path.parse(src).name; } }) ]
    )
)
```

... and where before, output `.js/.json` files would overwrite each other.
