### PR TITLE
Proposing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.idea
 node_modules/
-npm-debug.log
 dest/
+*.log
+*.bak
+
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .gitignore
 
+.idea
 node_modules/
 npm-debug.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.4.0 - 2016-5-7
+
+- Support for class-names inside pseudo-selectors like: ".foo:not(.bar)"
+- Added new "output" option, aggregating "dist", "outputName" and "type" into a single option, with fallback to original options
+- Allowing for explicit/template/callback values for options: "classnameFormat", "output", "dist", "outputName", "type"
+- Code refactor
+
 # 0.3.1 - 2016-5-2
 
 Add customize output file name.[[@ofzza](https://github.com/ofzza)] [[#12](https://github.com/ctxhou/postcss-hash-classname/issues/12)]

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ This plugin is inspired by [extract-text-webpack-plugin](https://github.com/webp
 **Input**
 
 ```css
-.foo {
+.foo:not(.bar) {
   ...
 }
 ```
 
 **Output**
 ```css
-.foo-sdijhfdsifj1 {
+.foo-7snm3d:not(.bar-8kb5qn) {
   ...
 }
 ```
@@ -34,7 +34,8 @@ then it would generate the corresponding `js/json` file.
 
 ```js
 module.exports = {
-  foo: "foo-sdijhfdsifj1"
+  "foo": "foo-7snm3d",
+  "bar": "bar-8kb5qn"
 }
 ```
 
@@ -82,103 +83,149 @@ gulp.task('default', function() {
 
 ### Options
 
+
 #### `hashType`
 
-Value: `sha1`, `md5`, `sha256`, `sha512`
+Hashing algorithm used when hashing classnames and source files' paths.
 
-Default: `md5`
+Default: `"md5"`
+
+Value: `"sha1"`, `"md5"`, `"sha256"`, `"sha512"`
+
 
 #### `digestType`
 
-Value: `hex`, `base26`, `base32`, `base36`, `base49`, `base52`, `base58`, `base62`, `base64`
+Hash output format.
 
-Default: `base32`
+Default: `"base32"`
+
+Allowed values: `"hex"`, `"base26"`, `"base32"`, `"base36"`, `"base49"`, `"base52"`, `"base58"`, `"base62"`, `"base64"`
+
 
 #### `maxLength`
 
-Value: maxLength the maximum length in chars
+Hash output max length.
 
-Default: 6
+Default: `6`
 
-**ps**: reference [loader-utils.getHashDigest](https://github.com/webpack/loader-utils#gethashdigest) to know more.
+Allowed values: maxLength the maximum length in chars (See [loader-utils.getHashDigest](https://github.com/webpack/loader-utils#gethashdigest) for reference)
+
 
 #### `classnameFormat`
 
+Used to set the output format of your classname.
+
 Default: `[classname]-[hash]`
 
-You can set the output format of your classname.
+Allowed values:
 
-Take `.example` this class name as the example:
+* Explicit value: `"my-classname"`
 
-* without hash string. (it return the origin classname)
+` .A, .b { ... } ` => ` .myclassname, .my-classname { ... } `
 
-`[classname]` => output: `example`
+* Template value: `"myclass-[classname]-[hash]"`
 
-* with prefix and without hash string
+` .A, .b { ... } ` => ` .myclass-A-425tvq, .myclass-b-5gbwsr { ... } `
 
-`prefix-[classname]` => output: `prefix-example`
+  Template words supported: `"classname"`, `"hash"`, `"classnamehash"`, `"sourcepathash"`
 
-* with prefix, suffix and hash string
+* Callback function (gets passed original classname and source file's path): `(classname, sourcePath) => { return classname + '-' + Math.round(1000*Math.random()); }`
 
-`prefix-[classname]-suffix-[hash] => output: `prefix-example-suffix-sdjif12`
+` .A, .b { ... } ` => ` .A-881, .b-123 { ... } `
 
-Of course, you can insert any word at any position you want, like
 
-`prefix_[classname]___sufix-[hash]-hey111`
+### `output`
 
-Just remember to keep the `[classname]` and `[hash]` word.
+Defines output file's path.
 
-**ps**:
+Default: `none` (if not set, will be constructed from options `dist`, `outputName` and `type`)
 
-```
-You may find that you dont need to write [classname].
+Allowed values:
 
-Yeah it's permit. I don't add too many limititation.
+* Explicit value: `"./style.js"`
 
-Maybe you would need your classname without origin classname in some case.
-```
+`./css/style.css` => `./style.js`
 
-#### `outputName`
+* Template value: `"[dir]/[name]-output.json"`
 
-filename of the `.js/.json`
+`./css/style.css` => `./css/style-output.json`
 
-Default: `style`
+  Template words supported: `"root"`, `"dir"`, `"base"`, `"ext"`, `"name"` (See [path.parse()](https://nodejs.org/api/path.html) for reference)
 
-You can set the output format of your `.js/.json` file's filename.
+* Callback function (gets passed source file's path): `(sourcePath) => { return Math.round(1000*Math.random()) + '.js'; }`
 
-Take this source file `mystyle.css` as the example:
+`./css/style.css` => `./114.js`
 
-* keeping original filename
-
-`[name]` => output: `mystyle.js/json`
-
-* with prefix and keeping original filename
-
-`prefix-[name]` => output: `prefix-mystyle.js/json`
-
-* with prefix, suffix keeping original filename
-
-`prefix-[name]-suffix` => output: `prefix-mystyle-suffix.js/json`
-
-You can also make `outputName` a callback function that resolves the file on the spot.
-
-The callback function will get the source file's path passed as only argument if source file is known:
-
-* use callback function
-
-function (source) { return (source ? path.parse(source).name : 'style'; } => output: `mystyle.js/json`
 
 #### `dist`
 
-destination folder of your output js/json
+Defines output file's target directory. Used only is `output` option empty.
 
-Default: same path with css file
+Default: Same path as source file's
+
+Allowed values:
+
+* Explicit value: `"./processed-styles"`
+
+`./css/style.css` => `./processed-styles/style.js`
+
+* Template value: `"[dir]/processed-styles"`
+
+`./css/style.css` => `./css/processed-styles/style.js`
+
+  Template words supported: `"root"`, `"dir"`, `"base"`, `"ext"`, `"name"` (See [path.parse()](https://nodejs.org/api/path.html) for reference)
+
+* Callback function (gets passed source file's path): `(sourcePath) => { return sourcePath + '/processed-styles'; }`
+
+`./css/style.css` => `./css/processed-styles/style.js`
+
+
+#### `outputName`
+
+Defines output file's filename. Used only is `output` option empty.
+
+Default: `"style"`
+
+Allowed values:
+
+* Explicit value: `"my-style"`
+
+`./css/style.css` => `./my-style.js`
+
+* Template value: `"[name]-processed"`
+
+`./css/style.css` => `./style-processed.js`
+
+  Template words supported: `"root"`, `"dir"`, `"base"`, `"ext"`, `"name"` (See [path.parse()](https://nodejs.org/api/path.html) for reference)
+
+* Callback function (gets passed source file's path): `(sourcePath) => { return Math.round(1000*Math.random()); }`
+
+`./css/style.css` => `./984.js`
+
+
 
 #### `type`
 
-Value: `.js` or `.json`
+Defines output file's extension - `".js"` and `".json"` supported. Used only is `output` option empty.
 
-Default: `.js`
+Default: `".js"`
+
+Allowed values:
+
+* Explicit value: `".json"`
+
+`./css/style.css` => `./style.json`
+
+* Template value: `"[ext].js"`
+
+`./css/style.css` => `./style.css.js`
+
+  Template words supported: `"root"`, `"dir"`, `"base"`, `"ext"`, `"name"` (See [path.parse()](https://nodejs.org/api/path.html) for reference)
+
+* Callback function (gets passed source file's path): `(sourcePath) => { return Math.round(1000*Math.random()) + '.js'; }`
+
+`./css/style.css` => `./style.984.js`
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ Allowed values:
 
   Template words supported: `"classname"`, `"hash"`, `"classnamehash"`, `"sourcepathash"`
 
-* Callback function (gets passed original classname and source file's path): `(classname, sourcePath) => { return classname + '-' + Math.round(1000*Math.random()); }`
+* Callback function (gets passed original classname and source file's path): `(classname, sourcePath) => { return path.parse(sourcePath).name + '-' + classname; }`
 
-` .A, .b { ... } ` => ` .A-881, .b-123 { ... } `
+foo.css: ` .A, .b { ... } ` => ` .foo.-A, .foo-b { ... } `
+
+bar.css:` .A, .b { ... } ` => ` .bar-A, .bar-b { ... } `
 
 
 ### `output`

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ function plugin(opts) {
   opts.maxLength = opts.maxLength || 6;
   opts.classnameFormat = opts.classnameFormat || "[classname]-[hash]";
   opts.output = opts.output || null;
-  opts.dist = opts.dist || './';
+  opts.dist = opts.dist || '.';
   opts.outputName = opts.outputName || 'style';
   opts.type  = opts.type || '.js';
 
@@ -262,8 +262,8 @@ function plugin(opts) {
 
     }
 
-    // If output file resolved, write to output file
-    if (outputFile) fs.writeFile(outputFile, formatFileOutput(mappings, path.parse(outputFile).ext));
+    // If output file resolved, write to output file (in case of multiple writes to same file, sync write makes sure streams don't overlap)
+    if (outputFile) fs.writeFileSync(outputFile, formatFileOutput(mappings, path.parse(outputFile).ext));
 
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-hash-classname",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "a postcss plugin can change your classname",
   "main": "index.js",
   "keywords": [

--- a/test/dist/style.js
+++ b/test/dist/style.js
@@ -1,1 +1,4 @@
-module.exports={"asjidf":"prefix-asjidf"}j8gya"}
+module.exports={
+  "asjidf": "prefix-asjidf"
+}8gya"
+}

--- a/test/dist/style.js
+++ b/test/dist/style.js
@@ -1,4 +1,0 @@
-module.exports={
-  "asjidf": "prefix-asjidf"
-}8gya"
-}

--- a/test/dist/test1.js
+++ b/test/dist/test1.js
@@ -1,3 +1,0 @@
-module.exports={
-  "test": "test-8qqhmk"
-}

--- a/test/dist/test1.js
+++ b/test/dist/test1.js
@@ -1,1 +1,3 @@
-module.exports={"test":"test-8qqhmk"}
+module.exports={
+  "test": "test-8qqhmk"
+}

--- a/test/dist/test2.js
+++ b/test/dist/test2.js
@@ -1,4 +1,0 @@
-module.exports={
-  "asjidf": "asjidf-5j8gya",
-  "sdf": "sdf-hn3hq7"
-}

--- a/test/dist/test2.js
+++ b/test/dist/test2.js
@@ -1,1 +1,4 @@
-module.exports={"asjidf":"asjidf-5j8gya","sdf":"sdf-hn3hq7"}
+module.exports={
+  "asjidf": "asjidf-5j8gya",
+  "sdf": "sdf-hn3hq7"
+}

--- a/test/dist/validate.js
+++ b/test/dist/validate.js
@@ -1,5 +1,0 @@
-module.exports={
-  "asjidf": "asjidf-5j8gya",
-  "djif": "djif-4zw7xd",
-  "sdf": "sdf-hn3hq7"
-}

--- a/test/dist/validate.js
+++ b/test/dist/validate.js
@@ -1,1 +1,5 @@
-module.exports={"asjidf":"asjidf-5j8gya","djif":"djif-4zw7xd","sdf":"sdf-hn3hq7"}
+module.exports={
+  "asjidf": "asjidf-5j8gya",
+  "djif": "djif-4zw7xd",
+  "sdf": "sdf-hn3hq7"
+}

--- a/test/test-expected.css
+++ b/test/test-expected.css
@@ -5,7 +5,7 @@
 .sdf-hn3hq7, .tee-6n4cxy, body {
     color: white;
 }
-.adf-986n6q {
+.adf-986n6q:not(.sdf-hn3hq7) {
     color: yellow;
 }
 

--- a/test/test.css
+++ b/test/test.css
@@ -5,7 +5,7 @@
 .sdf, .tee, body {
     color: white;
 }
-.adf {
+.adf:not(.sdf) {
     color: yellow;
 }
 


### PR DESCRIPTION
I'm proposing few updates and new features to the plugin:

1) The plugin was only renaming class-names inside normal selectors, and ignoring class-names that could appear inside pseudo selectors - currently only such example I know of is ".foo:not(.bar)", where current implementation would rename ".foo", but wouldn't process ".bar".

2) I've added support for 3 types of input values to following options: "classnameFormat", "dist", "outputName" and "type" - the input value types are:
- explicit string value
- template string value
- callback function returning a string value

... allowed template words and expected callback function format for each of the properties is documented in README.md and in code.

3) Added an additional "output" option, that takes a full path for the output file. This is because when using callbacks to determine output file based on input file's path it is much easier to manage a single callback function than to have to manage 3.

---

Mostly because of the pseudo-selectors fix I had to do some fairly major code refactoring.
The here proposed implementation should still have full compatibility with previous versions and is still passing existing tests ...
